### PR TITLE
fixed bug for mulit part city names

### DIFF
--- a/chalice/.chalice/policy-dev.json
+++ b/chalice/.chalice/policy-dev.json
@@ -10,7 +10,7 @@
       "Resource": [
         "*"
       ],
-      "Sid": "bffd5bd5c9fb4ea391d22a5574e5d628"
+      "Sid": "5998acfc294f4cdfb1e38b845088db12"
     },
     {
       "Effect": "Allow",

--- a/chalice/app.py
+++ b/chalice/app.py
@@ -15,6 +15,7 @@ app.debug = True
 
 @app.route('/citydeals/{city}',cors=True)
 def get_deals(city):
+    city = city.title()
     x = TheFlightDeal(city)
     y = SecretFlying(city)
     e = EmailScraper(city, "", [x, y])


### PR DESCRIPTION
chalice endpoint failed to return results if either part of the name of city was capitalized. 
made the city change to .title to fix. pushed to chalice. 